### PR TITLE
Fix for build errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 description = "Automatically execute wrapped functions in a sandboxed process."
 
 [dependencies]
-bincode = "1.0.0-alpha7"
+bincode = { git = "https://github.com/bincode-org/bincode.git", tag = "v1.0.0-alpha7" }
 lazy_static = "0.2.6"
 libc = "0.2.21"
 memmap = { version = "0.5.2", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,8 @@ pub use serde::{Serialize, Deserialize};
 pub static SANDCRUST_DEFAULT_SHM_SIZE: usize = 2097152;
 
 use std::io::{Read, Write};
-
+use std::time::Duration;
+use std::thread;
 
 // main data structure for sandcrust
 #[doc(hidden)]


### PR DESCRIPTION
The current version of Sandcrust does not compile when used as a dependency to another crate due to version of bincode required ([v1.0.0-alpha7](https://docs.rs/bincode/1.0.0-alpha7/bincode/index.html)) having been yanked from crates.io and missing use declarations for `std::time::Duration` and `std::thread`.

It can still be compiled on its own thanks to the provided Cargo.lock file, but this PR fixes the build issues that prevents it currently from being used a dependency.